### PR TITLE
Ob 338 delete all empty items

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Adds collection-management functionality to an element with a repeating template
 1. Optionally add trash/un-trash button. (The _lcbTrashMe method toggles trashing.) Example:
 
         <button on-tap="_lcbTrashMe">TRASH / UNTRASH THIS ITEM</button>
-1. Empty the trash by calling lcbEmptyTrash().
+1. Delete trashed items by calling lcbEmptyTrash().
+1. Delete empty items by calling lcbDeleteEmpties(). An item is considered empty if it is an empty object or each value of the object is empty.
 1. Optionally define the 'lcb-trashed' class in the element's dom module to indicate which items are trashed.
 
 ## Dependencies

--- a/demo/index.html
+++ b/demo/index.html
@@ -62,6 +62,8 @@
 
 <paper-button class="colorful" raised onClick="emptyTrash()">Empty Trash</paper-button>
 
+<paper-button class="colorful" raised onClick="deleteEmpties()">Delete Empties</paper-button>
+
 <demo-collection id="someDemoItems" lcb-items-name="employees" fire-log/>
 
 <script>
@@ -96,6 +98,9 @@
   }
   function emptyTrash() {
     myEl.lcbEmptyTrash();
+  }
+  function deleteEmpties() {
+    myEl.lcbDeleteEmpties();
   }
 </script>
 

--- a/ll-collection-behavior.html
+++ b/ll-collection-behavior.html
@@ -185,8 +185,8 @@
      */
     lcbIsEmptyItem: function (item) {
       var _this = this;
-      return _this.lcbIsEmptyVal(item) || !_.find(_.values(item), function (val) {
-            return !_this.lcbIsEmptyVal(val);
+      return this.lcbIsEmptyValue(item) || !_.find(_.values(item), function (val) {
+            return !_this.lcbIsEmptyValue(val);
           });
     },
 
@@ -197,7 +197,7 @@
      *
      * @returns {boolean}
      */
-    lcbIsEmptyVal: function (val) {
+    lcbIsEmptyValue: function (val) {
       return _.isEmpty(_.trim(val));
     },
 

--- a/ll-collection-behavior.html
+++ b/ll-collection-behavior.html
@@ -97,7 +97,7 @@
      * @param data {object} Optional data for new item.
      */
     lcbAdd: function (data) {
-      if(!_.isArray(this[this.lcbItemsName])) {
+      if (!_.isArray(this[this.lcbItemsName])) {
         this[this.lcbItemsName] = new Array();
       }
       this.push(this.lcbItemsName, _.isPlainObject(data) ? data : {});

--- a/ll-collection-behavior.html
+++ b/ll-collection-behavior.html
@@ -177,16 +177,37 @@
     },
 
     /**
-     * Returns true if each value of item is empty.
+     * Return true if item is empty or item is object and each value is empty.
      *
-     * @param item {object}
+     * @param {object} item
+     *
+     * @returns {boolean}
      */
-    lcbIsEmptyItem: function(item) {
-      return !_.find(_.values(item), function (val) {
-        return !_.isEmpty(val);
-      });
+    lcbIsEmptyItem: function (item) {
+      var _this = this;
+      return _this.lcbIsEmptyVal(item) || !_.find(_.values(item), function (val) {
+            return !_this.lcbIsEmptyVal(val);
+          });
     },
 
+    /**
+     * Return true if trimmed value is empty.
+     *
+     * @param {*} val
+     *
+     * @returns {boolean}
+     */
+    lcbIsEmptyVal: function (val) {
+      return _.isEmpty(_.trim(val));
+    },
+
+    /**
+     * Return true if number is valid index of items.
+     *
+     * @param {number} idx
+     *
+     * @returns {boolean}
+     */
     _isValidIndex: function (idx) {
       return _.isNumber(idx) && _.inRange(idx, this[this.lcbItemsName].length);
     },

--- a/ll-collection-behavior.html
+++ b/ll-collection-behavior.html
@@ -142,7 +142,9 @@
         var item = evt.model.item;
         var trashed = _.isBoolean(item.lcbTrashed) ? !item.lcbTrashed : true;
         evt.model.set('item.lcbTrashed', trashed);
-        this.toggleClass('lcb-trashed', trashed, evt.model._rootDataHost.children[evt.model.index]);
+        if (evt.model._nodes && evt.model._nodes[0] && evt.model._nodes[0].parentNode) {
+          this.toggleClass('lcb-trashed', trashed, evt.model._nodes[0].parentNode);
+        }
         this._fireLogFire('lcb-trashed', _.cloneDeep(item));
       }
     },

--- a/ll-collection-behavior.html
+++ b/ll-collection-behavior.html
@@ -85,7 +85,8 @@
     /**
      * Get an item by index.
      *
-     * @param idx {number}
+     * @param {number} idx
+     * @returns {object}
      */
     lcbGetItemByIndex: function (idx) {
       if (this._isValidIndex(idx)) {
@@ -96,7 +97,7 @@
     /**
      * Add item to collection.
      *
-     * @param data {object} Optional data for new item.
+     * @param {object} data Optional data for new item.
      */
     lcbAdd: function (data) {
       if (!_.isArray(this[this.lcbItemsName])) {
@@ -108,7 +109,7 @@
     /**
      * Delete an item by index.
      *
-     * @param idx {number}
+     * @param {number}
      */
     lcbDelete: function (idx) {
       if (this._isValidIndex(idx)) {
@@ -121,7 +122,7 @@
     /**
      * Delete the item that sent the 'lcb-delete-me' event.
      *
-     * @param evt {object}
+     * @param {object} evt
      * @private
      */
     _lcbDeleteMe: function (evt) {
@@ -133,7 +134,7 @@
     /**
      * Set to true, or toggle, the boolean 'lcbTrashed' property of the item that sent the 'lcb-trash-me' event.
      *
-     * @param evt {object}
+     * @param {object} evt
      * @private
      */
     _lcbTrashMe: function (evt) {
@@ -162,7 +163,7 @@
      * Delete all items that the supplied deleteCheckFunc function returns true for.
      * deleteCheckFunc takes 2 arguments: item and idx (the index of the item)
      *
-     * @param deleteCheckFunc {function}
+     * @param {function} deleteCheckFunc
      */
     lcbDeleteItems: function (deleteCheckFunc) {
       if (_.isFunction(deleteCheckFunc)) {

--- a/ll-collection-behavior.html
+++ b/ll-collection-behavior.html
@@ -156,7 +156,10 @@
     },
 
     lcbDeleteEmpties: function () {
-      this.lcbDeleteItems(this.lcbIsEmptyItem);
+      var _this = this;
+      this.lcbDeleteItems(function(item){
+        return _this.lcbIsEmptyItem(item);
+      });
     },
 
     /**

--- a/ll-collection-behavior.html
+++ b/ll-collection-behavior.html
@@ -13,12 +13,13 @@
    * Adds collection-management functionality to an element with a repeating template.
    *
    * ### Features:
-
-   * - Add item with optional data
-   * - Delete item by index, or when item fires event
+   *
+   * - Add item with optional data.
+   * - Delete item by index, or when item fires event.
+   * - Delete all empty items.
    * - Trash / un-trash item when item fires event.
    * - Toggles HTML class 'lcb-trashed' on the item's element.
-   * - Empty trash
+   * - Empty trash.
    *
    * ### Usage
    *
@@ -56,9 +57,10 @@
    *
    * 1. Optional: Add a delete button to each item by adding it within the dom-repeat template. Example:
    *        <button on-tap="_lcbDeleteMe">DELETE THIS ITEM</button>
+   * 1. Delete empty items by calling lcbDeleteEmpties(). An item is considered empty if it is an empty object or each value of the object is empty.
    * 1. Optional: Add trash/un-trash button. (The _lcbTrashMe method toggles trashing.) Example:
    *        <button on-tap="_lcbTrashMe">TRASH / UNTRASH THIS ITEM</button>
-   * 1. Empty the trash by calling lcbEmptyTrash().
+   * 1. Delete trashed items by calling lcbEmptyTrash().
    * 1. Optionally define the 'lcb-trashed' class in the element's dom module to style trashed items.
    *
    * @demo

--- a/ll-collection-behavior.html
+++ b/ll-collection-behavior.html
@@ -147,11 +147,40 @@
      * Delete all trashed items.
      */
     lcbEmptyTrash: function () {
-      var _this = this;
-      _.forEachRight(this[this.lcbItemsName], function (item, idx) {
-        if (item.lcbTrashed) {
-          _this.lcbDelete(idx);
-        }
+      this.lcbDeleteItems(function (item) {
+        return item.lcbTrashed;
+      });
+    },
+
+    lcbDeleteEmpties: function () {
+      this.lcbDeleteItems(this.lcbIsEmptyItem);
+    },
+
+    /**
+     * Delete all items that the supplied deleteCheckFunc function returns true for.
+     * deleteCheckFunc takes 2 arguments: item and idx (the index of the item)
+     *
+     * @param deleteCheckFunc {function}
+     */
+    lcbDeleteItems: function (deleteCheckFunc) {
+      if (_.isFunction(deleteCheckFunc)) {
+        var _this = this;
+        _.forEachRight(this[this.lcbItemsName], function (item, idx) {
+          if (deleteCheckFunc(item, idx)) {
+            _this.lcbDelete(idx);
+          }
+        });
+      }
+    },
+
+    /**
+     * Returns true if each value of item is empty.
+     *
+     * @param item {object}
+     */
+    lcbIsEmptyItem: function(item) {
+      return !_.find(_.values(item), function (val) {
+        return !_.isEmpty(val);
       });
     },
 

--- a/ll-collection-behavior.html
+++ b/ll-collection-behavior.html
@@ -157,7 +157,7 @@
 
     lcbDeleteEmpties: function () {
       var _this = this;
-      this.lcbDeleteItems(function(item){
+      this.lcbDeleteItems(function (item) {
         return _this.lcbIsEmptyItem(item);
       });
     },

--- a/test/tests.html
+++ b/test/tests.html
@@ -38,6 +38,11 @@
       {
         firstName: 'Bob',
         lastName: 'Guccione'
+      },
+      {},
+      {
+        firstName: '',
+        lastName: ''
       }
     ];
     return myEl;
@@ -59,13 +64,13 @@
           firstName: 'Testing',
           lastName: 'Maniac'
         });
-        expect(myEl.employees.length).to.eql(6);
-        expect(myEl.employees[5].lastName).to.eql('Maniac');
+        expect(myEl.employees.length).to.eql(8);
+        expect(myEl.employees[7].lastName).to.eql('Maniac');
       });
 
       it('should delete an item by index', function () {
         myEl.lcbDelete(2);
-        expect(myEl.employees.length).to.eql(5);
+        expect(myEl.employees.length).to.eql(7);
         expect(myEl.employees[2].firstName).to.eql('Sally');
       });
     });
@@ -78,7 +83,7 @@
       it('should delete an item that fires an event', function (done) {
         myEl.addEventListener('lcb-deleted', function (evt) {
           expect(evt.detail.firstName).to.eql('Grover');
-          expect(myEl.employees.length).to.eql(4);
+          expect(myEl.employees.length).to.eql(6);
           expect(myEl.employees[0].firstName).to.eql('Bill');
           done();
         });
@@ -86,39 +91,62 @@
       });
     });
 
-    describe('item self-trashing', function() {
+    describe('deleting empty items', function() {
+
+      var myEl = getPreparedElement();
+      document.body.appendChild(myEl);
+
+      it('should determine whether a value is empty', function () {
+        expect(myEl.lcbIsEmptyValue()).to.be.true;
+        expect(myEl.lcbIsEmptyValue(' ')).to.be.true;
+        expect(myEl.lcbIsEmptyValue('hello')).to.be.false;
+      });
+
+      it('should determine whether an item is empty', function () {
+        expect(myEl.lcbIsEmptyItem()).to.be.true;
+        expect(myEl.lcbIsEmptyItem({})).to.be.true;
+        expect(myEl.lcbIsEmptyItem({first:'', last:''})).to.be.true;
+        expect(myEl.lcbIsEmptyItem({first:'', last:''})).to.be.true;
+      });
+
+      it('should delete all empty items', function () {
+        myEl.lcbDeleteEmpties();
+        expect(myEl.employees.length).to.eql(5);
+      });
+
+    });
+
+    describe('trash', function() {
 
       var myEl = getPreparedElement();
       document.body.appendChild(myEl);
       var trashButtons = Polymer.dom(myEl).querySelectorAll('.trashButton');
 
-      it('should mark an item as trashed when the item fires an event', function (done) {
-        var lis = function (evt) {
-          myEl.removeEventListener('lcb-trashed', lis);
-          expect(evt.detail.firstName).to.eql('Grover');
-          expect(evt.detail.lcbTrashed).to.be.true;
-          done();
-        };
-        myEl.addEventListener('lcb-trashed', lis);
-        myEl.$$('.trashButton').click();
-      });
+      describe('item self-trashing', function() {
 
-      it('should mark another item as trashed when the item fires an event', function (done) {
-        var lis = function (evt) {
-          myEl.removeEventListener('lcb-trashed', lis);
-          expect(evt.detail.firstName).to.eql('Bill');
-          expect(evt.detail.lcbTrashed).to.be.true;
-          done();
-        };
-        myEl.addEventListener('lcb-trashed', lis);
-        var trashButtons = Polymer.dom(myEl.root).querySelectorAll('.trashButton');
-        trashButtons[1].click();
-      });
+        it('should mark an item as trashed when the item fires an event', function (done) {
+          var lis = function (evt) {
+            myEl.removeEventListener('lcb-trashed', lis);
+            expect(evt.detail.firstName).to.eql('Grover');
+            expect(evt.detail.lcbTrashed).to.be.true;
+            done();
+          };
+          myEl.addEventListener('lcb-trashed', lis);
+          myEl.$$('.trashButton').click();
+        });
 
-      it('should empty trash by deleting all items marked as trashed', function () {
-        myEl.lcbEmptyTrash();
-        expect(myEl.employees.length).to.eql(3);
-        expect(myEl.employees[0].lastName).to.eql('Jones');
+        it('should mark another item as trashed when the item fires an event', function (done) {
+          var lis = function (evt) {
+            myEl.removeEventListener('lcb-trashed', lis);
+            expect(evt.detail.firstName).to.eql('Bill');
+            expect(evt.detail.lcbTrashed).to.be.true;
+            done();
+          };
+          myEl.addEventListener('lcb-trashed', lis);
+          var trashButtons = Polymer.dom(myEl.root).querySelectorAll('.trashButton');
+          trashButtons[1].click();
+        });
+
       });
 
     });


### PR DESCRIPTION
This PR:
- Adds method "lcbDeleteItems" to delete all items for whom a supplied function returns true. (Could not simply use a lodash method on the items array because repeating template items have to be deleted using special Polymer methods.)
- Adds method "lcbDeleteEmpties" that uses method "lcbDeleteItems"
- Adds supporting methods "lcbIsEmptyItem" and "lcbIsEmptyValue"
- Adds "Delete Empties" button to demo.
- Adds tests.
